### PR TITLE
Add attestation provider, read attestation with AttestationInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "lint-staged": "^13.0.3"
   },
   "dependencies": {
+    "@ethereum-attestation-service/eas-sdk": "^2.1.4",
+    "ethers": "^6.12.1",
     "mapbox-gl": "^3.3.0",
     "react": "latest",
     "react-copy-to-clipboard": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint-staged": "^13.0.3"
   },
   "dependencies": {
-    "@ethereum-attestation-service/eas-sdk": "^2.1.4",
+    "@ethereum-attestation-service/eas-sdk": "1.6.1",
     "ethers": "^6.12.1",
     "mapbox-gl": "^3.3.0",
     "react": "latest",

--- a/packages/nextjs/EAS.config.ts
+++ b/packages/nextjs/EAS.config.ts
@@ -1,0 +1,10 @@
+export type EASConfig = {
+  EAS_CONTRACT_SEPOLIA: string;
+};
+
+const easConfig = {
+  // EAS.sol contract Sepolia
+  EAS_CONTRACT_SEPOLIA: "0xC2679fBD37d54388Ce493F1DB75320D236e1815e", // Sepolia v0.26,
+} as const satisfies EASConfig;
+
+export default easConfig;

--- a/packages/nextjs/EAS.config.ts
+++ b/packages/nextjs/EAS.config.ts
@@ -1,10 +1,12 @@
 export type EASConfig = {
   EAS_CONTRACT_SEPOLIA: string;
+  ATTESTATION_ID: string;
 };
 
 const easConfig = {
   // EAS.sol contract Sepolia
   EAS_CONTRACT_SEPOLIA: "0xC2679fBD37d54388Ce493F1DB75320D236e1815e", // Sepolia v0.26,
+  ATTESTATION_ID: "0xff08bbf3d3e6e0992fc70ab9b9370416be59e87897c3d42b20549901d2cccc3e",
 } as const satisfies EASConfig;
 
 export default easConfig;

--- a/packages/nextjs/app/attestationInfo/page.tsx
+++ b/packages/nextjs/app/attestationInfo/page.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import React from "react";
+import React, { useContext } from "react";
 import type { NextPage } from "next";
+import { EASContext } from "~~/components/EasContextProvider";
 
 // import Link from "next/link";
 
 const CheckinFrom: NextPage = () => {
+  const eas = useContext(EASContext);
+  console.log("[🧪 DEBUG](eas Instance):", eas);
+
   return (
     <>
       <div className="flex items-center flex-col w-full flex-grow">

--- a/packages/nextjs/app/attestationInfo/page.tsx
+++ b/packages/nextjs/app/attestationInfo/page.tsx
@@ -1,20 +1,47 @@
 "use client";
 
-import React, { useContext } from "react";
+import React, { useContext, useEffect, useState } from "react";
+import { Attestation } from "@ethereum-attestation-service/eas-sdk";
 import type { NextPage } from "next";
+import easConfig from "~~/EAS.config";
 import { EASContext } from "~~/components/EasContextProvider";
 
 // import Link from "next/link";
 
 const CheckinFrom: NextPage = () => {
-  const eas = useContext(EASContext);
-  console.log("[🧪 DEBUG](eas Instance):", eas);
+  const { eas, isReady } = useContext(EASContext);
+  const [attestation, setAttestation] = useState<Attestation>();
+
+  useEffect(() => {
+    if (!isReady) return;
+
+    eas
+      .getAttestation(easConfig.ATTESTATION_ID)
+      .then(attestation => {
+        console.log("[🧪 DEBUG](attestation):", attestation);
+        setAttestation(attestation);
+      })
+      .catch(err => {
+        console.log("[🧪 DEBUG](err):", err);
+        console.log("[🧪 DEBUG](eas):", eas);
+      });
+  }, [eas, isReady]);
 
   return (
     <>
       <div className="flex items-center flex-col w-full flex-grow">
         <div className="flex-grow center w-full">
           <h2>attestation info</h2>
+          <ul>uid:{attestation?.uid}</ul>
+          <ul>schema:{attestation?.schema}</ul>
+          <ul>refUID:{attestation?.refUID}</ul>
+          <ul>time:{attestation?.time}</ul>
+          <ul>expirationTime:{attestation?.expirationTime}</ul>
+          <ul>revocationTime:{attestation?.revocationTime}</ul>
+          <ul>recipient:{attestation?.recipient}</ul>
+          <ul>attester:{attestation?.attester}</ul>
+          <ul>revocable:{attestation?.revocable}</ul>
+          <ul>data:{attestation?.data}</ul>
         </div>
       </div>
     </>

--- a/packages/nextjs/app/attestationInfo/page.tsx
+++ b/packages/nextjs/app/attestationInfo/page.tsx
@@ -12,18 +12,17 @@ const CheckinFrom: NextPage = () => {
   const { eas, isReady } = useContext(EASContext);
   const [attestation, setAttestation] = useState<Attestation>();
 
+  // Get attestation from EAS api
   useEffect(() => {
     if (!isReady) return;
-
     eas
-      .getAttestation(easConfig.ATTESTATION_ID)
+      .getAttestation(easConfig.ATTESTATION_ID) // TODO: Read attestation from url slug.
       .then(attestation => {
         console.log("[🧪 DEBUG](attestation):", attestation);
         setAttestation(attestation);
       })
       .catch(err => {
         console.log("[🧪 DEBUG](err):", err);
-        console.log("[🧪 DEBUG](eas):", eas);
       });
   }, [eas, isReady]);
 
@@ -31,6 +30,7 @@ const CheckinFrom: NextPage = () => {
     <>
       <div className="flex items-center flex-col w-full flex-grow">
         <div className="flex-grow center w-full">
+          {/* TODO: Replace with daisyUI components */}
           <h2>attestation info</h2>
           <ul>uid:{attestation?.uid}</ul>
           <ul>schema:{attestation?.schema}</ul>

--- a/packages/nextjs/components/EasContextProvider.tsx
+++ b/packages/nextjs/components/EasContextProvider.tsx
@@ -1,0 +1,22 @@
+// import { EAS, Offchain, SchemaEncoder, SchemaRegistry } from "@ethereum-attestation-service/eas-sdk";
+import React, { createContext, useEffect } from "react";
+import { EAS } from "@ethereum-attestation-service/eas-sdk";
+import { foundry } from "viem/chains";
+import easConfig from "~~/EAS.config";
+// import { foundry } from "viem/chains";
+import { useEthersSigner } from "~~/utils/useEthersSigner";
+
+const EASContractAddress = easConfig.EAS_CONTRACT_SEPOLIA;
+const eas = new EAS(EASContractAddress);
+
+const EASContext = createContext(eas);
+
+const EASProvider = ({ children }: { children: React.ReactNode }) => {
+  const signer = useEthersSigner({ chainId: foundry.id });
+  useEffect(() => {
+    signer && eas.connect(signer);
+  });
+  return <EASContext.Provider value={eas}>{children}</EASContext.Provider>;
+};
+
+export { EASContext, EASProvider };

--- a/packages/nextjs/components/EasContextProvider.tsx
+++ b/packages/nextjs/components/EasContextProvider.tsx
@@ -1,7 +1,6 @@
 // import { EAS, Offchain, SchemaEncoder, SchemaRegistry } from "@ethereum-attestation-service/eas-sdk";
-import React, { createContext, useEffect } from "react";
+import React, { createContext, useEffect, useState } from "react";
 import { EAS } from "@ethereum-attestation-service/eas-sdk";
-import { foundry } from "viem/chains";
 import easConfig from "~~/EAS.config";
 // import { foundry } from "viem/chains";
 import { useEthersSigner } from "~~/utils/useEthersSigner";
@@ -9,14 +8,23 @@ import { useEthersSigner } from "~~/utils/useEthersSigner";
 const EASContractAddress = easConfig.EAS_CONTRACT_SEPOLIA;
 const eas = new EAS(EASContractAddress);
 
-const EASContext = createContext(eas);
+const EASContext = createContext({ eas, isReady: false });
 
 const EASProvider = ({ children }: { children: React.ReactNode }) => {
-  const signer = useEthersSigner({ chainId: foundry.id });
+  const signer = useEthersSigner();
+  const [signerReady, setSignerReady] = useState(false);
+
   useEffect(() => {
-    signer && eas.connect(signer);
+    signer?.provider
+      .getSigner()
+      .then(() => {
+        signer && eas.connect(signer);
+        setSignerReady(true);
+      })
+      .catch(err => console.log("[🧪 DEBUG](err):", err));
   });
-  return <EASContext.Provider value={eas}>{children}</EASContext.Provider>;
+
+  return <EASContext.Provider value={{ eas, isReady: signerReady }}>{children}</EASContext.Provider>;
 };
 
 export { EASContext, EASProvider };

--- a/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
+++ b/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
@@ -10,6 +10,7 @@ import { ProgressBar } from "../components/scaffold-eth/ProgressBar";
 import { useNativeCurrencyPrice } from "../hooks/scaffold-eth";
 import { useGlobalState } from "../services/store/store";
 import { wagmiConfig } from "../services/web3/wagmiConfig";
+import { EASProvider } from "./EasContextProvider";
 import { RainbowKitProvider, darkTheme } from "@rainbow-me/rainbowkit";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "react-hot-toast";
@@ -59,7 +60,9 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
       <QueryClientProvider client={queryClient}>
         <ProgressBar />
         <RainbowKitProvider avatar={BlockieAvatar} theme={darkTheme()}>
-          <ScaffoldEthApp>{children}</ScaffoldEthApp>
+          <EASProvider>
+            <ScaffoldEthApp>{children}</ScaffoldEthApp>
+          </EASProvider>
         </RainbowKitProvider>
       </QueryClientProvider>
     </WagmiProvider>

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -10,7 +10,7 @@ export type ScaffoldConfig = {
 
 const scaffoldConfig = {
   // The networks on which your DApp is live
-  targetNetworks: [chains.foundry],
+  targetNetworks: [chains.foundry, chains.sepolia],
 
   // The interval at which your front-end polls the RPC servers for new data
   // it has no effect if you only target the local network (default is 4000)

--- a/packages/nextjs/utils/useEthersSigner.ts
+++ b/packages/nextjs/utils/useEthersSigner.ts
@@ -18,5 +18,5 @@ export function clientToSigner(client: Client<Transport, Chain, Account>) {
 /** Hook to convert a viem Wallet Client to an ethers.js Signer. */
 export function useEthersSigner({ chainId }: { chainId?: number } = {}) {
   const { data: client } = useConnectorClient<Config>({ chainId });
-  return useMemo(() => (client ? clientToSigner(client) : undefined), [client, client?.account]);
+  return useMemo(() => (client ? clientToSigner(client) : undefined), [client]);
 }

--- a/packages/nextjs/utils/useEthersSigner.ts
+++ b/packages/nextjs/utils/useEthersSigner.ts
@@ -17,6 +17,6 @@ export function clientToSigner(client: Client<Transport, Chain, Account>) {
 
 /** Hook to convert a viem Wallet Client to an ethers.js Signer. */
 export function useEthersSigner({ chainId }: { chainId?: number } = {}) {
-  const { data: signer } = useConnectorClient<Config>({ chainId });
-  return useMemo(() => (signer ? clientToSigner(signer) : undefined), [signer]);
+  const { data: client } = useConnectorClient<Config>({ chainId });
+  return useMemo(() => (client ? clientToSigner(client) : undefined), [client, client?.account]);
 }

--- a/packages/nextjs/utils/useEthersSigner.ts
+++ b/packages/nextjs/utils/useEthersSigner.ts
@@ -1,0 +1,22 @@
+import { useMemo } from "react";
+import { BrowserProvider, JsonRpcSigner } from "ethers";
+import type { Account, Chain, Client, Transport } from "viem";
+import { type Config, useConnectorClient } from "wagmi";
+
+export function clientToSigner(client: Client<Transport, Chain, Account>) {
+  const { account, chain, transport } = client;
+  const network = {
+    chainId: chain.id,
+    name: chain.name,
+    ensAddress: chain.contracts?.ensRegistry?.address,
+  };
+  const provider = new BrowserProvider(transport, network);
+  const signer = new JsonRpcSigner(provider, account.address);
+  return signer;
+}
+
+/** Hook to convert a viem Wallet Client to an ethers.js Signer. */
+export function useEthersSigner({ chainId }: { chainId?: number } = {}) {
+  const { data: signer } = useConnectorClient<Config>({ chainId });
+  return useMemo(() => (signer ? clientToSigner(signer) : undefined), [signer]);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -764,18 +764,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethereum-attestation-service/eas-sdk@npm:^2.1.4":
-  version: 2.1.4
-  resolution: "@ethereum-attestation-service/eas-sdk@npm:2.1.4"
+"@ethereum-attestation-service/eas-sdk@npm:1.6.1":
+  version: 1.6.1
+  resolution: "@ethereum-attestation-service/eas-sdk@npm:1.6.1"
   dependencies:
     "@ethereum-attestation-service/eas-contracts": 1.4.1
     ethers: ^6.11.1
-    js-base64: ^3.7.7
+    js-base64: ^3.7.6
     lodash: ^4.17.21
     multiformats: 9.9.0
     pako: ^2.1.0
     semver: ^7.6.0
-  checksum: 60e6d64c7d20d1ab57272a3de5d425c70f2d7a7c8b96c08be684b243e56cfc63dfb8c546910bba04fef21a0fb9d48d8190b1188ee9930755de9abe5361bdd462
+  checksum: 8aa310b8599e9a575d0e66291408163a8ffea335999134a452f3c85f59abaac7a48953623895a3d464914ed3196e5e4556c98b834d6387f56fd3f0c724e9b58b
   languageName: node
   linkType: hard
 
@@ -10313,7 +10313,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-base64@npm:^3.7.7":
+"js-base64@npm:^3.7.6":
   version: 3.7.7
   resolution: "js-base64@npm:3.7.7"
   checksum: d1b02971db9dc0fd35baecfaf6ba499731fb44fe3373e7e1d6681fbd3ba665f29e8d9d17910254ef8104e2cb8b44117fe4202d3dc54c7cafe9ba300fe5433358
@@ -13979,7 +13979,7 @@ __metadata:
   resolution: "se-2@workspace:."
   dependencies:
     "@commitlint/cli": ^19.3.0
-    "@ethereum-attestation-service/eas-sdk": ^2.1.4
+    "@ethereum-attestation-service/eas-sdk": 1.6.1
     "@types/mapbox-gl": ^3
     "@types/react": latest
     "@types/react-copy-to-clipboard": ^5.0.7

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,6 +19,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adraffy/ens-normalize@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@adraffy/ens-normalize@npm:1.10.1"
+  checksum: 0836f394ea256972ec19a0b5e78cb7f5bcdfd48d8a32c7478afc94dd53ae44c04d1aa2303d7f3077b4f3ac2323b1f557ab9188e8059978748fdcd83e04a80dcc
+  languageName: node
+  linkType: hard
+
 "@adraffy/ens-normalize@npm:1.9.4":
   version: 1.9.4
   resolution: "@adraffy/ens-normalize@npm:1.9.4"
@@ -745,6 +752,30 @@ __metadata:
   version: 8.50.0
   resolution: "@eslint/js@npm:8.50.0"
   checksum: 302478f2acaaa7228729ec6a04f56641590185e1d8cd1c836a6db8a6b8009f80a57349341be9fbb9aa1721a7a569d1be3ffc598a33300d22816f11832095386c
+  languageName: node
+  linkType: hard
+
+"@ethereum-attestation-service/eas-contracts@npm:1.4.1":
+  version: 1.4.1
+  resolution: "@ethereum-attestation-service/eas-contracts@npm:1.4.1"
+  dependencies:
+    hardhat: 2.22.1
+  checksum: 9b78873bbb9efd8540fd332bedd660750c7bba0202ee894a1eaec5f13fc6f691332bf8cdedefe49b043e5be748c2ed7889b5e53f617a8585c5ae1d2e4351a350
+  languageName: node
+  linkType: hard
+
+"@ethereum-attestation-service/eas-sdk@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@ethereum-attestation-service/eas-sdk@npm:2.1.4"
+  dependencies:
+    "@ethereum-attestation-service/eas-contracts": 1.4.1
+    ethers: ^6.11.1
+    js-base64: ^3.7.7
+    lodash: ^4.17.21
+    multiformats: 9.9.0
+    pako: ^2.1.0
+    semver: ^7.6.0
+  checksum: 60e6d64c7d20d1ab57272a3de5d425c70f2d7a7c8b96c08be684b243e56cfc63dfb8c546910bba04fef21a0fb9d48d8190b1188ee9930755de9abe5361bdd462
   languageName: node
   linkType: hard
 
@@ -1862,6 +1893,85 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nomicfoundation/edr-darwin-arm64@npm:0.3.7":
+  version: 0.3.7
+  resolution: "@nomicfoundation/edr-darwin-arm64@npm:0.3.7"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-darwin-x64@npm:0.3.7":
+  version: 0.3.7
+  resolution: "@nomicfoundation/edr-darwin-x64@npm:0.3.7"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-linux-arm64-gnu@npm:0.3.7":
+  version: 0.3.7
+  resolution: "@nomicfoundation/edr-linux-arm64-gnu@npm:0.3.7"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-linux-arm64-musl@npm:0.3.7":
+  version: 0.3.7
+  resolution: "@nomicfoundation/edr-linux-arm64-musl@npm:0.3.7"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-linux-x64-gnu@npm:0.3.7":
+  version: 0.3.7
+  resolution: "@nomicfoundation/edr-linux-x64-gnu@npm:0.3.7"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-linux-x64-musl@npm:0.3.7":
+  version: 0.3.7
+  resolution: "@nomicfoundation/edr-linux-x64-musl@npm:0.3.7"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-win32-x64-msvc@npm:0.3.7":
+  version: 0.3.7
+  resolution: "@nomicfoundation/edr-win32-x64-msvc@npm:0.3.7"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr@npm:^0.3.1":
+  version: 0.3.7
+  resolution: "@nomicfoundation/edr@npm:0.3.7"
+  dependencies:
+    "@nomicfoundation/edr-darwin-arm64": 0.3.7
+    "@nomicfoundation/edr-darwin-x64": 0.3.7
+    "@nomicfoundation/edr-linux-arm64-gnu": 0.3.7
+    "@nomicfoundation/edr-linux-arm64-musl": 0.3.7
+    "@nomicfoundation/edr-linux-x64-gnu": 0.3.7
+    "@nomicfoundation/edr-linux-x64-musl": 0.3.7
+    "@nomicfoundation/edr-win32-x64-msvc": 0.3.7
+  dependenciesMeta:
+    "@nomicfoundation/edr-darwin-arm64":
+      optional: true
+    "@nomicfoundation/edr-darwin-x64":
+      optional: true
+    "@nomicfoundation/edr-linux-arm64-gnu":
+      optional: true
+    "@nomicfoundation/edr-linux-arm64-musl":
+      optional: true
+    "@nomicfoundation/edr-linux-x64-gnu":
+      optional: true
+    "@nomicfoundation/edr-linux-x64-musl":
+      optional: true
+    "@nomicfoundation/edr-win32-x64-msvc":
+      optional: true
+  checksum: bad2d4c916c01dc219086def3a3c29d17834f5eb3a8898f3a79e4e4270c013c2417ff7d2eea1401bf6d1e436fcdbf5d7e4db6a2fdf76ed2495f6f900ab3e0273
+  languageName: node
+  linkType: hard
+
 "@nomicfoundation/ethereumjs-block@npm:5.0.2":
   version: 5.0.2
   resolution: "@nomicfoundation/ethereumjs-block@npm:5.0.2"
@@ -1908,6 +2018,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nomicfoundation/ethereumjs-common@npm:4.0.4":
+  version: 4.0.4
+  resolution: "@nomicfoundation/ethereumjs-common@npm:4.0.4"
+  dependencies:
+    "@nomicfoundation/ethereumjs-util": 9.0.4
+  checksum: ce3f6e4ae15b976efdb7ccda27e19aadb62b5ffee209f9503e68b4fd8633715d4d697c0cc10ccd35f5e4e977edd05100d0f214e28880ec64fff77341dc34fcdf
+  languageName: node
+  linkType: hard
+
 "@nomicfoundation/ethereumjs-ethash@npm:3.0.2":
   version: 3.0.2
   resolution: "@nomicfoundation/ethereumjs-ethash@npm:3.0.2"
@@ -1944,6 +2063,15 @@ __metadata:
   bin:
     rlp: bin/rlp
   checksum: a74434cadefca9aa8754607cc1ad7bb4bbea4ee61c6214918e60a5bbee83206850346eb64e39fd1fe97f854c7ec0163e01148c0c881dda23881938f0645a0ef2
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/ethereumjs-rlp@npm:5.0.4":
+  version: 5.0.4
+  resolution: "@nomicfoundation/ethereumjs-rlp@npm:5.0.4"
+  bin:
+    rlp: bin/rlp.cjs
+  checksum: ee2c2e5776c73801dc5ed636f4988b599b4563c2d0037da542ea57eb237c69dd1ac555f6bcb5e06f70515b6459779ba0d68252a6e105132b4659ab4bf62919b0
   languageName: node
   linkType: hard
 
@@ -1988,6 +2116,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nomicfoundation/ethereumjs-tx@npm:5.0.4":
+  version: 5.0.4
+  resolution: "@nomicfoundation/ethereumjs-tx@npm:5.0.4"
+  dependencies:
+    "@nomicfoundation/ethereumjs-common": 4.0.4
+    "@nomicfoundation/ethereumjs-rlp": 5.0.4
+    "@nomicfoundation/ethereumjs-util": 9.0.4
+    ethereum-cryptography: 0.1.3
+  peerDependencies:
+    c-kzg: ^2.1.2
+  peerDependenciesMeta:
+    c-kzg:
+      optional: true
+  checksum: 0f1c87716682ccbcf4d92ffc6cf8ab557e658b90319d82be3219a091a736859f8803c73c98e4863682e3e86d264751c472d33ff6d3c3daf4e75b5f01d0af8fa3
+  languageName: node
+  linkType: hard
+
 "@nomicfoundation/ethereumjs-util@npm:9.0.2":
   version: 9.0.2
   resolution: "@nomicfoundation/ethereumjs-util@npm:9.0.2"
@@ -1996,6 +2141,21 @@ __metadata:
     "@nomicfoundation/ethereumjs-rlp": 5.0.2
     ethereum-cryptography: 0.1.3
   checksum: 3a08f7b88079ef9f53b43da9bdcb8195498fd3d3911c2feee2571f4d1204656053f058b2f650471c86f7d2d0ba2f814768c7cfb0f266eede41c848356afc4900
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/ethereumjs-util@npm:9.0.4":
+  version: 9.0.4
+  resolution: "@nomicfoundation/ethereumjs-util@npm:9.0.4"
+  dependencies:
+    "@nomicfoundation/ethereumjs-rlp": 5.0.4
+    ethereum-cryptography: 0.1.3
+  peerDependencies:
+    c-kzg: ^2.1.2
+  peerDependenciesMeta:
+    c-kzg:
+      optional: true
+  checksum: 754439f72b11cad2d8986707ad020077dcc763c4055f73e2668a0b4cadb22aa4407faa9b3c587d9eb5b97ac337afbe037eb642bc1d5a16197284f83db3462cbe
   languageName: node
   linkType: hard
 
@@ -4494,6 +4654,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-align@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "ansi-align@npm:3.0.1"
+  dependencies:
+    string-width: ^4.1.0
+  checksum: 6abfa08f2141d231c257162b15292467081fa49a208593e055c866aa0455b57f3a86b5a678c190c618faa79b4c59e254493099cb700dd9cf2293c6be2c8f5d8d
+  languageName: node
+  linkType: hard
+
 "ansi-colors@npm:3.2.3":
   version: 3.2.3
   resolution: "ansi-colors@npm:3.2.3"
@@ -5132,6 +5301,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"boxen@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "boxen@npm:5.1.2"
+  dependencies:
+    ansi-align: ^3.0.0
+    camelcase: ^6.2.0
+    chalk: ^4.1.0
+    cli-boxes: ^2.2.1
+    string-width: ^4.2.2
+    type-fest: ^0.20.2
+    widest-line: ^3.1.0
+    wrap-ansi: ^7.0.0
+  checksum: 82d03e42a72576ff235123f17b7c505372fe05c83f75f61e7d4fa4bcb393897ec95ce766fecb8f26b915f0f7a7227d66e5ec7cef43f5b2bd9d3aeed47ec55877
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.11
   resolution: "brace-expansion@npm:1.1.11"
@@ -5349,7 +5534,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase@npm:^6.0.0":
+"camelcase@npm:^6.0.0, camelcase@npm:^6.2.0":
   version: 6.3.0
   resolution: "camelcase@npm:6.3.0"
   checksum: 8c96818a9076434998511251dcb2761a94817ea17dbdc37f47ac080bd088fc62c7369429a19e2178b993497132c8cbcf5cc1f44ba963e76782ba469c0474938d
@@ -5592,6 +5777,13 @@ __metadata:
   version: 2.2.0
   resolution: "clean-stack@npm:2.2.0"
   checksum: 2ac8cd2b2f5ec986a3c743935ec85b07bc174d5421a5efc8017e1f146a1cf5f781ae962618f416352103b32c9cd7e203276e8c28241bbe946160cab16149fb68
+  languageName: node
+  linkType: hard
+
+"cli-boxes@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "cli-boxes@npm:2.2.1"
+  checksum: be79f8ec23a558b49e01311b39a1ea01243ecee30539c880cf14bf518a12e223ef40c57ead0cb44f509bffdffc5c129c746cd50d863ab879385370112af4f585
   languageName: node
   linkType: hard
 
@@ -7754,6 +7946,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ethers@npm:^6.11.1, ethers@npm:^6.12.1":
+  version: 6.12.1
+  resolution: "ethers@npm:6.12.1"
+  dependencies:
+    "@adraffy/ens-normalize": 1.10.1
+    "@noble/curves": 1.2.0
+    "@noble/hashes": 1.3.2
+    "@types/node": 18.15.13
+    aes-js: 4.0.0-beta.5
+    tslib: 2.4.0
+    ws: 8.5.0
+  checksum: ddf398c91f584b9e643740ec17a9c82b4a1c4ea3fb6efd00f1a043b89d1ec6f9427aa80894f75850ee805722e91b8d054bce18579a2c621226302c096774df90
+  languageName: node
+  linkType: hard
+
 "ethjs-unit@npm:0.1.6":
   version: 0.1.6
   resolution: "ethjs-unit@npm:0.1.6"
@@ -9008,6 +9215,67 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hardhat@npm:2.22.1":
+  version: 2.22.1
+  resolution: "hardhat@npm:2.22.1"
+  dependencies:
+    "@ethersproject/abi": ^5.1.2
+    "@metamask/eth-sig-util": ^4.0.0
+    "@nomicfoundation/edr": ^0.3.1
+    "@nomicfoundation/ethereumjs-common": 4.0.4
+    "@nomicfoundation/ethereumjs-tx": 5.0.4
+    "@nomicfoundation/ethereumjs-util": 9.0.4
+    "@nomicfoundation/solidity-analyzer": ^0.1.0
+    "@sentry/node": ^5.18.1
+    "@types/bn.js": ^5.1.0
+    "@types/lru-cache": ^5.1.0
+    adm-zip: ^0.4.16
+    aggregate-error: ^3.0.0
+    ansi-escapes: ^4.3.0
+    boxen: ^5.1.2
+    chalk: ^2.4.2
+    chokidar: ^3.4.0
+    ci-info: ^2.0.0
+    debug: ^4.1.1
+    enquirer: ^2.3.0
+    env-paths: ^2.2.0
+    ethereum-cryptography: ^1.0.3
+    ethereumjs-abi: ^0.6.8
+    find-up: ^2.1.0
+    fp-ts: 1.19.3
+    fs-extra: ^7.0.1
+    glob: 7.2.0
+    immutable: ^4.0.0-rc.12
+    io-ts: 1.10.4
+    keccak: ^3.0.2
+    lodash: ^4.17.11
+    mnemonist: ^0.38.0
+    mocha: ^10.0.0
+    p-map: ^4.0.0
+    raw-body: ^2.4.1
+    resolve: 1.17.0
+    semver: ^6.3.0
+    solc: 0.7.3
+    source-map-support: ^0.5.13
+    stacktrace-parser: ^0.1.10
+    tsort: 0.0.1
+    undici: ^5.14.0
+    uuid: ^8.3.2
+    ws: ^7.4.6
+  peerDependencies:
+    ts-node: "*"
+    typescript: "*"
+  peerDependenciesMeta:
+    ts-node:
+      optional: true
+    typescript:
+      optional: true
+  bin:
+    hardhat: internal/cli/bootstrap.js
+  checksum: 6494697d37198d32b9151e8303b8e771f1d10f50ddd5488c619a8b6d36c6ee391a274ce75f7ac17b574fec84e6e1dc11f63487d308013873183cd2af58865200
+  languageName: node
+  linkType: hard
+
 "hardhat@npm:^2.19.4":
   version: 2.19.4
   resolution: "hardhat@npm:2.19.4"
@@ -10042,6 +10310,13 @@ __metadata:
   bin:
     jiti: bin/jiti.js
   checksum: a7bd5d63921c170eaec91eecd686388181c7828e1fa0657ab374b9372bfc1f383cf4b039e6b272383d5cb25607509880af814a39abdff967322459cca41f2961
+  languageName: node
+  linkType: hard
+
+"js-base64@npm:^3.7.7":
+  version: 3.7.7
+  resolution: "js-base64@npm:3.7.7"
+  checksum: d1b02971db9dc0fd35baecfaf6ba499731fb44fe3373e7e1d6681fbd3ba665f29e8d9d17910254ef8104e2cb8b44117fe4202d3dc54c7cafe9ba300fe5433358
   languageName: node
   linkType: hard
 
@@ -11379,7 +11654,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"multiformats@npm:^9.4.2":
+"multiformats@npm:9.9.0, multiformats@npm:^9.4.2":
   version: 9.9.0
   resolution: "multiformats@npm:9.9.0"
   checksum: d3e8c1be400c09a014f557ea02251a2710dbc9fca5aa32cc702ff29f636c5471e17979f30bdcb0a9cbb556f162a8591dc2e1219c24fc21394a56115b820bb84e
@@ -12186,6 +12461,13 @@ __metadata:
   version: 2.2.0
   resolution: "p-try@npm:2.2.0"
   checksum: f8a8e9a7693659383f06aec604ad5ead237c7a261c18048a6e1b5b85a5f8a067e469aa24f5bc009b991ea3b058a87f5065ef4176793a200d4917349881216cae
+  languageName: node
+  linkType: hard
+
+"pako@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "pako@npm:2.1.0"
+  checksum: 71666548644c9a4d056bcaba849ca6fd7242c6cf1af0646d3346f3079a1c7f4a66ffec6f7369ee0dc88f61926c10d6ab05da3e1fca44b83551839e89edd75a3e
   languageName: node
   linkType: hard
 
@@ -13697,11 +13979,13 @@ __metadata:
   resolution: "se-2@workspace:."
   dependencies:
     "@commitlint/cli": ^19.3.0
+    "@ethereum-attestation-service/eas-sdk": ^2.1.4
     "@types/mapbox-gl": ^3
     "@types/react": latest
     "@types/react-copy-to-clipboard": ^5.0.7
     "@types/react-dom": latest
     commitlint: ^19.3.0
+    ethers: ^6.12.1
     husky: ^8.0.1
     lint-staged: ^13.0.3
     mapbox-gl: ^3.3.0
@@ -14280,7 +14564,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
+"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.0.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.2, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
@@ -15986,6 +16270,15 @@ __metadata:
   dependencies:
     string-width: ^1.0.2 || 2 || 3 || 4
   checksum: d5fc37cd561f9daee3c80e03b92ed3e84d80dde3365a8767263d03dacfc8fa06b065ffe1df00d8c2a09f731482fcacae745abfbb478d4af36d0a891fad4834d3
+  languageName: node
+  linkType: hard
+
+"widest-line@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "widest-line@npm:3.1.0"
+  dependencies:
+    string-width: ^4.0.0
+  checksum: 03db6c9d0af9329c37d74378ff1d91972b12553c7d72a6f4e8525fe61563fa7adb0b9d6e8d546b7e059688712ea874edd5ded475999abdeedf708de9849310e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
- [x] Add a top level EAS provider.
- [x] Add useEthersSigner hook to transform from wagmi to ethers.js (EAS receives only ethersSigner).
- [x] Downgrad @ethereum-attestation-service/eas-sdk to v1.61 ([bug with provider](https://t.me/c/1923082540/2/3452)).
- [x] Read attestation using EAS SDK in `AttestationInfo` component.  

## Screenshot
<img width="1509" alt="Screen Shot 2024-05-06 at 04 55 10" src="https://github.com/AstralProtocol/eas-checkin-dapp/assets/7093389/ab9f6c57-6efb-4ee6-ab1b-888eef706613">
